### PR TITLE
Add Dockerised `postgres` database

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+name: 'url_shortener_db'
+volumes:
+  url_shortener_data:
+    driver: local
+services:
+  url_shortener_db:
+    container_name: url_shortener_db
+    image: postgres:latest
+    restart: always
+    env_file:
+        - path: .env
+    ports:
+      - 5432:5432
+    volumes:
+      - url_shortener_data:/var/lib/postgresql/data
+      - ./sql/:/docker-entrypoint-initdb.d

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS links CASCADE;
+
+-- Links table
+CREATE TABLE IF NOT EXISTS links (
+    link_id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    slug text UNIQUE NOT NULL,
+    long_url text UNIQUE NOT NULL
+);


### PR DESCRIPTION
The compose file loads the latest postgres image and builds a container.

It also creates a local volume and seeds the database with the schema in `sql/`.https://docs.github.com/articles/closing-issues-using-keywords.

## IMPORTANT

The Docker compose file reads the database variables from an `.env` file. You must create an `.env` when running this locally. 