### PR TITLE
30 create connection to database

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,13 @@
+import asyncio
 
 from dotenv import dotenv_values
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 """Get settings from .env"""
 SETTINGS: dict[str, str | None] = {**dotenv_values(dotenv_path=".env")}
@@ -14,6 +22,15 @@ db: dict[str, str | None] = {
 }
 
 DATABASE_URL: str = f"postgresql+psycopg_async://{db['user']}:{db['password']}@{db['host']}:{db['port']}/{db['dbname']}"
+
+""" Establish async connection to database """
+asyncio_engine: AsyncEngine = create_async_engine(url=DATABASE_URL, echo=True)
+
+async_session: async_sessionmaker[AsyncSession] = async_sessionmaker(
+    bind=asyncio_engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
 
 
 def main() -> None:

--- a/main.py
+++ b/main.py
@@ -1,8 +1,19 @@
-import os
 
 from dotenv import dotenv_values
 
-SETTINGS: dict[str, str | None] = {**dotenv_values(".env")}
+"""Get settings from .env"""
+SETTINGS: dict[str, str | None] = {**dotenv_values(dotenv_path=".env")}
+
+"""Construct database connection string"""
+db: dict[str, str | None] = {
+    "host": SETTINGS["POSTGRES_HOST"],
+    "port": SETTINGS["POSTGRES_PORT"],
+    "user": SETTINGS["POSTGRES_USER"],
+    "password": SETTINGS["POSTGRES_PASSWORD"],
+    "dbname": SETTINGS["POSTGRES_DB"],
+}
+
+DATABASE_URL: str = f"postgresql+psycopg_async://{db['user']}:{db['password']}@{db['host']}:{db['port']}/{db['dbname']}"
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 dev = [
     "coverage>=7.9.2",
     "pytest>=8.4.1",
+    "pytest-asyncio>=1.1.0",
     "ruff>=0.12.4",
 ]
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,19 @@
-from main import main
+import pytest
+from sqlalchemy import text
+
+from main import async_session, main
 
 
 class TestMain:
     def test_main_returns_none(self) -> None:
         assert main() is None
+
+    @pytest.mark.asyncio
+    async def test_database_async_connection(self) -> None:
+        async with async_session() as session:
+            result = await session.execute(text("SELECT 1"))
+            value = result.scalar()
+
+            assert value == 1, (
+                "Database connection failed or returned unexpected result"
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -131,6 +131,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -217,6 +229,7 @@ dependencies = [
 dev = [
     { name = "coverage" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -231,5 +244,6 @@ requires-dist = [
 dev = [
     { name = "coverage", specifier = ">=7.9.2" },
     { name = "pytest", specifier = ">=8.4.1" },
+    { name = "pytest-asyncio", specifier = ">=1.1.0" },
     { name = "ruff", specifier = ">=0.12.4" },
 ]


### PR DESCRIPTION
We're getting somewhere: this PR adds async tests to make sure we can async connect to the database. It adds a basic connection string, built using values in `.env` and then uses an async engine and async session factory to establish a connection to the database.