### PR TITLE
Create `Link` class

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,13 +1,14 @@
 import asyncio
 
 from dotenv import dotenv_values
-from sqlalchemy import text
+from sqlalchemy import Identity, Integer, String
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
     async_sessionmaker,
     create_async_engine,
 )
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 """Get settings from .env"""
 SETTINGS: dict[str, str | None] = {**dotenv_values(dotenv_path=".env")}
@@ -31,6 +32,27 @@ async_session: async_sessionmaker[AsyncSession] = async_sessionmaker(
     class_=AsyncSession,
     expire_on_commit=False,
 )
+
+"""SQLAlchemy models"""
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Link(Base):
+    __tablename__ = "links"
+
+    link_id: Mapped[int] = mapped_column(
+        Integer, Identity(always=True), primary_key=True
+    )
+    slug: Mapped[str] = mapped_column(String(), unique=True, index=True, nullable=False)
+    long_url: Mapped[str] = mapped_column(String(), unique=True, nullable=False)
+
+    def __repr__(self) -> str:
+        return (
+            f"Link(link_id={self.link_id}, slug={self.slug}, long_url={self.long_url})"
+        )
 
 
 def main() -> None:


### PR DESCRIPTION
Follows the `SQLAlchemy` documentation. Creates a base class and expands that with a Link class. The class matches the database schema.