### PR TITLE
14 create short url service

### DIFF
--- a/.github/workflows/pytest-coverage.yml
+++ b/.github/workflows/pytest-coverage.yml
@@ -24,6 +24,8 @@ jobs:
               POSTGRES_DB=${{ vars.POSTGRES_DB }}
               POSTGRES_HOST=${{ vars.POSTGRES_HOST }}
               POSTGRES_PORT=${{ vars.POSTGRES_PORT }}
+              SLUG_LENGTH=${{ vars.SLUG_LENGTH }}
+              BASE_URL=${{ vars.BASE_URL }}
               EOF
         - name: Install Docker
           uses: docker/setup-compose-action@v1

--- a/main.py
+++ b/main.py
@@ -97,6 +97,16 @@ async def generate_unique_slug(db: AsyncSession) -> str:
         if not slug_exists:
             return slug
 
+
+async def generate_short_url(db: AsyncSession, long_url: HttpUrl) -> str:
+    slug: str = await generate_unique_slug(db)
+    link = Link(slug=slug, long_url=long_url)
+    db.add(link)
+    await db.commit()
+    await db.refresh(link)
+    return f"{BASE_URL}/{slug}"
+
+
 def main() -> None:
     pass
 

--- a/main.py
+++ b/main.py
@@ -14,6 +14,9 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 """Get settings from .env"""
 SETTINGS: dict[str, str | None] = {**dotenv_values(dotenv_path=".env")}
 
+BASE_URL: str = SETTINGS["BASE_URL"]
+SLUG_LENGTH: int = int(SETTINGS["SLUG_LENGTH"])
+
 """Construct database connection string"""
 db: dict[str, str | None] = {
     "host": SETTINGS["POSTGRES_HOST"],

--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
 import asyncio
+import secrets
+import string
 
 from dotenv import dotenv_values
 from pydantic import BaseModel, Field, HttpUrl
@@ -77,6 +79,13 @@ class LongUrlReturn(BaseModel):
 class ShortUrlReturn(BaseModel):
     short_url: HttpUrl
 
+
+""" Slug / short link service """
+
+
+def generate_slug(length: int) -> str:
+    base62: str = string.ascii_letters + string.digits
+    return "".join(secrets.choice(seq=base62) for _ in range(length))
 
 def main() -> None:
     pass

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import string
 
 from dotenv import dotenv_values
 from pydantic import BaseModel, Field, HttpUrl
-from sqlalchemy import Identity, Integer, String
+from sqlalchemy import Identity, Integer, String, select
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -86,6 +86,16 @@ class ShortUrlReturn(BaseModel):
 def generate_slug(length: int) -> str:
     base62: str = string.ascii_letters + string.digits
     return "".join(secrets.choice(seq=base62) for _ in range(length))
+
+
+async def generate_unique_slug(db: AsyncSession) -> str:
+    while True:
+        slug: str = generate_slug(SLUG_LENGTH)
+        slug_exists: Link | None = await db.scalar(
+            select(Link).where(Link.slug == slug)
+        )
+        if not slug_exists:
+            return slug
 
 def main() -> None:
     pass


### PR DESCRIPTION
Adds tests and functions for the `create_short_url` service. This service takes in long urls, generates slugs, instantiates new objects using the database model, adds these to the database, and returns the new shortened URL.

I've split the service into separate functions to ensure readability.