### PR TITLE
16 create get long url service

### DIFF
--- a/main.py
+++ b/main.py
@@ -107,6 +107,18 @@ async def generate_short_url(db: AsyncSession, long_url: HttpUrl) -> str:
     return f"{BASE_URL}/{slug}"
 
 
+class NoMatchingSlugError(Exception):
+    def __init__(self, slug: str) -> None:
+        super().__init__(f"{slug} does not exist")
+
+
+async def get_long_url(db: AsyncSession, slug: str) -> str:
+    result: Link | None = await db.scalar(select(Link).where(Link.slug == slug))
+    if not result:
+        raise NoMatchingSlugError(slug)
+    return result.long_url
+
+
 def main() -> None:
     pass
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -150,3 +150,27 @@ class TestMain:
 
         assert isinstance(short_url, str)
         assert short_url == "https://jkwlsn.dev/A1b2C3d"
+
+    @pytest.mark.asyncio
+    async def test_long_url_with_matching_slug(self) -> None:
+        slug = "A1b2C3d"
+        long_url = "https://example.com/a/deep/page/and-some-more-information-here.html"
+        test_link = Link(link_id=1, slug=slug, long_url=long_url)
+        mock_db = AsyncMock(AsyncSession)
+        mock_db.scalar.return_value = test_link
+
+        result = await get_long_url(mock_db, slug)
+
+        assert result == long_url
+        assert mock_db.scalar.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_long_url_no_matching_slug(self) -> None:
+        slug = "an-invalid-slug"
+        mock_db = AsyncMock(AsyncSession)
+        mock_db.scalar.return_value = None
+
+        with pytest.raises(NoMatchingSlugError) as e:
+            await get_long_url(mock_db, slug)
+
+        assert "slug" in str(e.value)


### PR DESCRIPTION
This PR adds the `get_long_url` service. This is the service that will handle the `GET /{slug}` route. It's simpler than the `create_short_url` service, as all it does is read from the database.