### PR TITLE
FIX: broken validation of URL length

### DIFF
--- a/.github/workflows/pytest-coverage.yml
+++ b/.github/workflows/pytest-coverage.yml
@@ -26,6 +26,8 @@ jobs:
               POSTGRES_PORT=${{ vars.POSTGRES_PORT }}
               SLUG_LENGTH=${{ vars.SLUG_LENGTH }}
               BASE_URL=${{ vars.BASE_URL }}
+              MAX_URL_LENGTH=${{ vars.MAX_URL_LENGTH }}
+              MIN_URL_LENGTH=${{ vars.MIN_URL_LENGTH }}
               EOF
         - name: Install Docker
           uses: docker/setup-compose-action@v1


### PR DESCRIPTION
It turns out Pydantic doesn't automatically check for length, or raise errors.

You have to write your own validation functions yourself.

This commit reads MIN and MAX lengths from the `.env` and applies them in a field_validator to pydantic. It raises errors if the length is too short or too long.