### PR TITLE
Removes unused `asyncio` module

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import asyncio
 import secrets
 import string
 


### PR DESCRIPTION
This was previously used, but is now not necessary