### PR TITLE
50 review pydantic models

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,8 +4,7 @@ import string
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import RedirectResponse
-from pydantic import BaseModel, Field, HttpUrl, SecretStr, field_validator
-from pydantic_core import Url
+from pydantic import BaseModel, HttpUrl, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from sqlalchemy import Identity, Integer, String, select
 from sqlalchemy.dialects.postgresql import TEXT
@@ -105,9 +104,6 @@ class LongUrlAccept(BaseModel):
             raise ValueError(too_short)
         return long_url
 
-
-class SlugAccept(BaseModel):
-    slug: str = Field(pattern=r"^[A-Za-z0-9]{7}$")
 
 
 class LongUrlReturn(BaseModel):

--- a/main.py
+++ b/main.py
@@ -104,6 +104,13 @@ class LongUrlAccept(BaseModel):
             raise ValueError(too_short)
         return long_url
 
+    @field_validator("long_url")
+    @classmethod
+    def validate_reject_same_domain(cls, long_url: HttpUrl) -> HttpUrl:
+        same_host = "You can't make short links for this address"
+        if str(long_url.host) in str(settings.base_url):
+            raise ValueError(same_host)
+        return long_url
 
 
 class LongUrlReturn(BaseModel):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -72,24 +72,6 @@ class TestMain:
 
         assert "validation error" in str(e.value)
 
-    def test_accept_valid_slugs(self) -> None:
-        """Valid slugs should be valid"""
-        data: dict[str, str] = {"slug": "A1b2C3d"}
-
-        schema: SlugAccept = SlugAccept(**data)
-
-        assert isinstance(schema.slug, str)
-        assert str(schema.slug) == "A1b2C3d"
-
-    def test_do_not_accept_invalid_slugs(self) -> None:
-        """Invalid slugs should raise ValidationErrors"""
-        invalid_data: dict[str, str] = {"slug": "an-invalid-slug"}
-
-        with pytest.raises(ValidationError) as e:
-            schema: SlugAccept = SlugAccept(**invalid_data)
-
-        assert "validation error" in str(e.value)
-
     def test_return_valid_short_urls(self) -> None:
         """Application should return valid slugs"""
         data: dict[str, str] = {"short_url": "https://jkwlsn.dev/A1b2C3d"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -49,6 +49,15 @@ class TestMain:
 
         assert "validation error" in str(e.value)
 
+    def test_do_not_accept_recursive_long_urls(self) -> None:
+        """URLs from the same host should be rejected to prevent loops"""
+        invalid_data: dict[str, str] = {"long_url": "https://jkwlsn.dev/an-example-url"}
+
+        with pytest.raises(ValidationError) as e:
+            schema: LongUrlAccept = LongUrlAccept(**invalid_data)
+
+        assert "validation error" in str(e.value)
+
     def test_return_valid_long_urls(self) -> None:
         """Application should return valid URLs"""
         data: dict[str, str] = {


### PR DESCRIPTION
Removes unused `SlugAccept` model and updates the `long_url` with validation to prevent looping shortlinks.