### PR TITLE
Removes unused `LongUrlReturn`

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from database import get_db
 from exceptions import NoMatchingSlugError
-from schemas import LongUrlAccept, LongUrlReturn, ShortUrlReturn
+from schemas import LongUrlAccept, ShortUrlReturn
 from services.url import UrlService
 
 router = APIRouter()

--- a/schemas.py
+++ b/schemas.py
@@ -26,9 +26,5 @@ class LongUrlAccept(BaseModel):
         return long_url
 
 
-class LongUrlReturn(BaseModel):
-    long_url: HttpUrl
-
-
 class ShortUrlReturn(BaseModel):
     short_url: HttpUrl

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2,7 +2,6 @@ import pytest
 from sqlalchemy import text
 
 from database import async_session
-from main import *
 
 
 class TestDatabase:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -2,7 +2,7 @@ import pytest
 from pydantic import HttpUrl, ValidationError
 
 from main import *
-from schemas import LongUrlAccept, LongUrlReturn, ShortUrlReturn
+from schemas import LongUrlAccept, ShortUrlReturn
 
 
 class TestPydantic:
@@ -37,29 +37,6 @@ class TestPydantic:
 
         with pytest.raises(ValidationError) as e:
             schema: LongUrlAccept = LongUrlAccept(**invalid_data)
-
-        assert "validation error" in str(e.value)
-
-    def test_return_valid_long_urls(self) -> None:
-        """Application should return valid URLs"""
-        data: dict[str, str] = {
-            "long_url": "https://example.com/a/deep/page/and-some-more-information-here.html"
-        }
-
-        schema: LongUrlReturn = LongUrlReturn(**data)
-
-        assert isinstance(schema.long_url, HttpUrl)
-        assert (
-            str(schema.long_url)
-            == "https://example.com/a/deep/page/and-some-more-information-here.html"
-        )
-
-    def test_do_not_return_invalid_long_urls(self) -> None:
-        """Invalid short urls should not be returned"""
-        invalid_data: dict = {"long_url": "an-invalid-url"}
-
-        with pytest.raises(ValidationError) as e:
-            LongUrlReturn(**invalid_data)
 
         assert "validation error" in str(e.value)
 


### PR DESCRIPTION
The pydantic schema is never actually used. Instead the route returns a RedirectResponse, which cannot be validated with pydantic.