### PR TITLE
64 add link expiration

### DIFF
--- a/.github/workflows/pytest-coverage.yml
+++ b/.github/workflows/pytest-coverage.yml
@@ -28,6 +28,7 @@ jobs:
               BASE_URL=${{ vars.BASE_URL }}
               MAX_URL_LENGTH=${{ vars.MAX_URL_LENGTH }}
               MIN_URL_LENGTH=${{ vars.MIN_URL_LENGTH }}
+              MAX_LINK_AGE=${{ vars.MAX_LINK_AGE }}
               EOF
         - name: Install Docker
           uses: docker/setup-compose-action@v1

--- a/config/config.py
+++ b/config/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
     slug_length: int = 7
     max_url_length: int = 2048
     min_url_length: int = 15
+    max_link_age: int = 30
 
     postgres_host: str
     postgres_port: int

--- a/exceptions/exceptions.py
+++ b/exceptions/exceptions.py
@@ -1,5 +1,7 @@
 """Custom errors"""
 
+from config.config import settings
+
 
 class URLTooLongError(ValueError):
     def __init__(self, url: str, limit: int) -> None:
@@ -19,3 +21,10 @@ class SelfReferencingURLError(ValueError):
 class NoMatchingSlugError(Exception):
     def __init__(self, slug: str) -> None:
         super().__init__(f"{slug} does not exist")
+
+
+class LinkExpiredError(Exception):
+    def __init__(self, slug: str) -> None:
+        super().__init__(
+            f"{slug} has expired: older than {settings.max_link_age} days old."
+        )

--- a/models/models.py
+++ b/models/models.py
@@ -1,8 +1,11 @@
 """SQLAlchemy Models"""
 
-from sqlalchemy import Identity, Integer, String
+from datetime import datetime
+
+from sqlalchemy import DateTime, Identity, Integer, String
 from sqlalchemy.dialects.postgresql import TEXT
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy.sql import func
 
 from config.config import settings
 
@@ -22,6 +25,9 @@ class Link(Base):
     )
     long_url: Mapped[TEXT] = mapped_column(
         String(length=settings.max_url_length), nullable=False
+    )
+    created_ts: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
     )
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Adds extra feature: link expiration

When links are added, the current time is saved to the database in the `created_ts` field.

Max link age (in days) is defined in `.env`

Adds a function in the UrlService that checks if the link is older than the max age.

Raises LinkExpiredError if over max age, returns 410 status to end user.