### PR TITLE
Ensure Lifespan is called on startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,6 @@ async def lifespan(_: FastAPI) -> AsyncGenerator:
     yield
 
 
-app: FastAPI = FastAPI(title=settings.app_name)
+app: FastAPI = FastAPI(title=settings.app_name, lifespan=lifespan)
 
 app.include_router(shorten_router)


### PR DESCRIPTION
Lifespan wasn't being called properly (I probably broke it during refactoring), so tables weren't being created on a fresh start. I only discovered this during the final tests.