### PR TITLE
Changes test values from hardcoded to .env vars

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -9,12 +9,14 @@ from config.config import settings
 from exceptions.exceptions import LinkExpiredError, NoMatchingSlugError
 from main import app
 
+slug = "A1b2C3d"
+
 
 class TestRoutes:
     @pytest.mark.asyncio
     async def test_root(self) -> None:
         async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
+            transport=ASGITransport(app=app), base_url=str(settings.base_url)
         ) as ac:
             response = await ac.get("/")
 
@@ -25,20 +27,20 @@ class TestRoutes:
     async def test_return_short_url_valid_long_url(
         self, mock_create_short_url: MagicMock
     ) -> None:
-        mock_create_short_url.return_value = "https://jkwlsn.dev/A1b2C3d"
+        mock_create_short_url.return_value = f"{settings.base_url}{slug}"
         async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
+            transport=ASGITransport(app=app), base_url=str(settings.base_url)
         ) as ac:
             payload = {"long_url": "https://www.example.com/page"}
             response = await ac.post(url="/shorten", json=payload)
 
         assert response.status_code == 200
-        assert response.json() == {"short_url": "https://jkwlsn.dev/A1b2C3d"}
+        assert response.json() == {"short_url": f"{settings.base_url}{slug}"}
 
     @pytest.mark.asyncio
     async def test_can_not_return_short_url_invalid_long_url(self) -> None:
         async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
+            transport=ASGITransport(app=app), base_url=str(settings.base_url)
         ) as ac:
             payload = {"long_url": "an-invalid-url"}
             response = await ac.post(url="/shorten", json=payload)
@@ -48,7 +50,7 @@ class TestRoutes:
     @pytest.mark.asyncio
     async def test_can_not_return_short_url_long_url_too_long(self) -> None:
         async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
+            transport=ASGITransport(app=app), base_url=str(settings.base_url)
         ) as ac:
             payload = {"long_url": f"https://www.example.com/{'a' * 2500}"}
             response = await ac.post(url="/shorten", json=payload)
@@ -58,7 +60,7 @@ class TestRoutes:
     @pytest.mark.asyncio
     async def test_can_not_return_short_url_long_url_too_short(self) -> None:
         async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
+            transport=ASGITransport(app=app), base_url=str(settings.base_url)
         ) as ac:
             payload = {"long_url": "http://bit.ly/"}
             response = await ac.post(url="/shorten", json=payload)
@@ -73,7 +75,7 @@ class TestRoutes:
     ) -> None:
         mock_create_short_url.side_effect = Exception("Internal error")
         async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
+            transport=ASGITransport(app=app), base_url=str(settings.base_url)
         ) as ac:
             payload = {"long_url": "https://www.example.com/page"}
             response = await ac.post(url="/shorten", json=payload)
@@ -88,9 +90,9 @@ class TestRoutes:
     ) -> None:
         mock_get_long_url.return_value = "https://www.example.com/page"
         async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
+            transport=ASGITransport(app=app), base_url=str(settings.base_url)
         ) as ac:
-            response = await ac.get(url="/ABCD123")
+            response = await ac.get(url=f"/{slug}")
 
         assert response.status_code == 307
         assert response.is_redirect
@@ -102,9 +104,9 @@ class TestRoutes:
     ) -> None:
         mock_get_long_url.side_effect = NoMatchingSlugError("No matching slug found")
         async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
+            transport=ASGITransport(app=app), base_url=str(settings.base_url)
         ) as ac:
-            response = await ac.get(url="/ABCD123")
+            response = await ac.get(url=f"/{slug}")
 
         assert response.status_code == 404
 
@@ -117,9 +119,9 @@ class TestRoutes:
             "ABCD123", settings.max_url_age
         )
         async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
+            transport=ASGITransport(app=app), base_url=str(settings.base_url)
         ) as ac:
-            response = await ac.get(url="/ABCD123")
+            response = await ac.get(url=f"/{slug}")
         assert response.status_code == 410
         assert response.json() == {
             "detail": "ABCD123 has expired: older than 30 days old."

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,7 +1,14 @@
 import pytest
 from pydantic import HttpUrl, ValidationError
 
+from config.config import settings
 from schemas.schemas import LongUrlAccept, ShortUrlReturn
+
+slug = "A1b2C3d"
+invalid_url = "an-invalid-url"
+long_url = "https://example.com/a/deep/page/and-some-more-information-here.html"
+self_reference_url = f"{settings.base_url}an-example-url"
+valid_short_url = f"{settings.base_url}{slug}"
 
 
 class TestPydantic:
@@ -9,50 +16,45 @@ class TestPydantic:
 
     def test_accept_valid_long_urls(self) -> None:
         """Valid urls should be accepted"""
-        data: dict[str, str] = {
-            "long_url": "https://example.com/a/deep/page/and-some-more-information-here.html"
-        }
+        data: dict[str, str] = {"long_url": long_url}
 
         schema: LongUrlAccept = LongUrlAccept(**data)
 
         assert isinstance(schema.long_url, HttpUrl)
-        assert (
-            str(schema.long_url)
-            == "https://example.com/a/deep/page/and-some-more-information-here.html"
-        )
+        assert str(schema.long_url) == long_url
 
     def test_do_not_accept_invalid_long_urls(self) -> None:
         """Invalid urls should raise ValidationErrors"""
-        invalid_data: dict[str, str] = {"long_url": "an-invalid-url"}
+        invalid_data: dict[str, str] = {"long_url": invalid_url}
 
         with pytest.raises(ValidationError) as e:
             schema: LongUrlAccept = LongUrlAccept(**invalid_data)
 
-        assert "validation error" in str(e.value)
+        assert "long_url" in str(e.value)
 
     def test_do_not_accept_recursive_long_urls(self) -> None:
         """URLs from the same host should be rejected to prevent loops"""
-        invalid_data: dict[str, str] = {"long_url": "https://jkwlsn.dev/an-example-url"}
+        invalid_data: dict[str, str] = {"long_url": self_reference_url}
 
         with pytest.raises(ValidationError) as e:
             schema: LongUrlAccept = LongUrlAccept(**invalid_data)
 
-        assert "validation error" in str(e.value)
+        assert "long_url" in str(e.value)
 
     def test_pydantic_model_accept_valid_short_url(self) -> None:
         """The ShortUrlReturn model should accept valid short urls"""
-        data: dict[str, str] = {"short_url": "https://jkwlsn.dev/A1b2C3d"}
+        data: dict[str, str] = {"short_url": valid_short_url}
 
         schema: ShortUrlReturn = ShortUrlReturn(**data)
 
         assert isinstance(schema.short_url, HttpUrl)
-        assert str(schema.short_url) == "https://jkwlsn.dev/A1b2C3d"
+        assert str(schema.short_url) == valid_short_url
 
     def test_pydantic_model_reject_invalid_short_url(self) -> None:
         """The ShortUrlReturn model should reject invalid short urls"""
-        invalid_data: dict[str, str] = {"short_url": "an-invalid-url"}
+        invalid_data: dict[str, str] = {"short_url": invalid_url}
 
         with pytest.raises(ValidationError) as e:
             ShortUrlReturn(**invalid_data)
 
-        assert "validation error" in str(e.value)
+        assert "short_url" in str(e.value)

--- a/tests/test_url_service.py
+++ b/tests/test_url_service.py
@@ -48,7 +48,7 @@ class TestUrlService:
         long_url = "https://example.com/a/deep/page/and-some-more-information-here.html"
         short_url = await UrlService().create_short_url(mock_db, long_url)
         assert isinstance(short_url, str)
-        assert short_url == "https://jkwlsn.dev/A1b2C3d"
+        assert short_url == f"{settings.base_url}A1b2C3d"
 
     @pytest.mark.asyncio
     async def test_get_long_url_by_slug_success(self) -> None:


### PR DESCRIPTION
When testing dev setup, I found my hardcoded values were causing errors.

This replaces the hardcoded test values with values taken from `.env`