### PR TITLE
Prevent attestation being uploaded

### DIFF
--- a/.github/workflows/build-push-docker-hub.yml
+++ b/.github/workflows/build-push-docker-hub.yml
@@ -44,4 +44,5 @@ jobs:
         with:
           subject-name: index.docker.io/jkwlsn/url-shortener
           subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+          push-to-registry: false
+          show-summary: true


### PR DESCRIPTION
Apparently, Docker Hub doesn't support this, even though this workflow comes from the official GitHub/DockerHub documentation